### PR TITLE
Improve error handling

### DIFF
--- a/src/__tests__/fieldNotFoundMessageForType-test.ts
+++ b/src/__tests__/fieldNotFoundMessageForType-test.ts
@@ -1,0 +1,36 @@
+import { GraphQLObjectType, GraphQLString, GraphQLScalarType } from "graphql";
+import { fieldNotFoundMessageForType } from "..";
+
+describe("fieldNotFoundMessageForType", () => {
+  it("returns a helpful message for null", () => {
+    expect(fieldNotFoundMessageForType(null)).toBe(
+      "The type should not be null."
+    );
+  });
+
+  it("returns a helpful message for scalar types", () => {
+    expect(
+      fieldNotFoundMessageForType(
+        new GraphQLScalarType({
+          name: "Odd",
+          serialize(value) {
+            return value % 2 === 1 ? value : null;
+          }
+        })
+      )
+    ).toBe("The field has a scalar type, which means it supports no nesting.");
+  });
+
+  it("returns all field names for object type", () => {
+    expect(
+      fieldNotFoundMessageForType(
+        new GraphQLObjectType({
+          name: "Row",
+          fields: () => ({
+            id: { type: GraphQLString }
+          })
+        })
+      )
+    ).toBe("The only fields found in this Object are: id.");
+  });
+});

--- a/src/__tests__/graphqlObservable-test.ts
+++ b/src/__tests__/graphqlObservable-test.ts
@@ -540,7 +540,7 @@ describe("graphqlObservable", function() {
         "#",
         {},
         new Error(
-          "graphqlObservable error: resolver 'throwingResolver' throws this error: 'Error: my personal error'"
+          "reactive-graphql: resolver 'throwingResolver' throws this error: 'Error: my personal error'"
         )
       );
       const result = graphqlObservable(query, fieldResolverSchema, {});

--- a/src/__tests__/graphqlObservable-test.ts
+++ b/src/__tests__/graphqlObservable-test.ts
@@ -530,7 +530,7 @@ describe("graphqlObservable", function() {
       });
     });
 
-    itMarbles("nested resolvers pass down the context and parent", function(m) {
+    itMarbles("throwing an error results in an error observable", function(m) {
       const query = gql`
         query {
           throwingResolver
@@ -546,6 +546,26 @@ describe("graphqlObservable", function() {
       const result = graphqlObservable(query, fieldResolverSchema, {});
       m.expect(result.take(1)).toBeObservable(expected);
     });
+
+    itMarbles(
+      "accessing an unknown query field results in an error observable",
+      function(m) {
+        const query = gql`
+          query {
+            youDontKnowMe
+          }
+        `;
+        const expected = m.cold(
+          "#",
+          {},
+          new Error(
+            "reactive-graphql: field 'youDontKnowMe' was not found on type 'Query'. The only fields found in this Object are: plain,item,nested,throwingResolver."
+          )
+        );
+        const result = graphqlObservable(query, fieldResolverSchema, {});
+        m.expect(result.take(1)).toBeObservable(expected);
+      }
+    );
   });
 
   describe("Mutation", function() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,10 +253,7 @@ export default function graphqlObservable<T = object>(
 }
 
 function throwObservable(error: string): Observable<any> {
-  const graphqlErrorMessage = `graphqlObservable error: ${error}`;
-  const graphqlError = new Error(graphqlErrorMessage);
-
-  return Observable.throw(graphqlError);
+  return Observable.throw(new Error(`reactive-graphql: ${error}`));
 }
 
 function buildResolveArgs(definition: FieldNode, context: object) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -312,22 +312,28 @@ function resolveField(
   }
 
   const args = buildResolveArgs(definition, context);
-  const resolvedValue = field.resolve(
-    parent,
-    args,
-    context,
-    // @ts-ignore
-    null // that would be the info
-  );
+  try {
+    const resolvedValue = field.resolve(
+      parent,
+      args,
+      context,
+      // @ts-ignore
+      null // that would be the info
+    );
 
-  if (resolvedValue instanceof Observable) {
-    return resolvedValue;
+    if (resolvedValue instanceof Observable) {
+      return resolvedValue;
+    }
+
+    if (resolvedValue instanceof Promise) {
+      return Observable.fromPromise(resolvedValue);
+    }
+
+    // It seems like a plain value
+    return Observable.of(resolvedValue);
+  } catch (err) {
+    return throwObservable(
+      `resolver '${field.name}' throws this error: '${err}'`
+    );
   }
-
-  if (resolvedValue instanceof Promise) {
-    return Observable.fromPromise(resolvedValue);
-  }
-
-  // It seems like a plain value
-  return Observable.of(resolvedValue);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,10 @@ import {
   isTypeSystemDefinitionNode,
   isTypeSystemExtensionNode,
   Kind,
-  ArgumentNode
+  ArgumentNode,
+  isScalarType,
+  isEnumType,
+  isObjectType
 } from "graphql";
 
 // WARNING: This is NOT a spec complete graphql implementation
@@ -106,7 +109,11 @@ export default function graphqlObservable<T = object>(
       // Something unexpcected was passed into getField
       if (field === null) {
         return throwObservable(
-          `field was not of the right type. Given type: ${type}`
+          `field '${
+            definition.name.value
+          }' was not found on type '${type}'. ${fieldNotFoundMessageForType(
+            type
+          )}`
         );
       }
 
@@ -333,4 +340,26 @@ function resolveField(
       `resolver '${field.name}' throws this error: '${err}'`
     );
   }
+}
+
+export function fieldNotFoundMessageForType(type: GraphQLType | null): string {
+  if (type === null) {
+    return "The type should not be null.";
+  }
+
+  if (isScalarType(type)) {
+    return "The field has a scalar type, which means it supports no nesting.";
+  }
+
+  if (isEnumType(type)) {
+    return "The field has an enum type, which means it supports no nesting.";
+  }
+
+  if (isObjectType(type)) {
+    return `The only fields found in this Object are: ${Object.keys(
+      type.getFields()
+    )}.`;
+  }
+
+  return "";
 }


### PR DESCRIPTION
This PR does multiple things (separated by commits):

1) Catch errors thrown in field resolvers, so that they come in the rxjs realm
2) Rename graphqlObservable to reactive-graphql in an error message
3) Give more details in error messages (Closing #1) and thereby improving the developer experience