### PR TITLE
Fix resolvers returning undefined

### DIFF
--- a/src/__tests__/graphqlObservable-test.ts
+++ b/src/__tests__/graphqlObservable-test.ts
@@ -88,6 +88,7 @@ const fieldResolverSchema = makeExecutableSchema({
     type Plain {
       noFieldResolver: String!
       fieldResolver: String!
+      fieldResolvesUndefined: String!
       giveMeTheParentFieldResolver: String!
       giveMeTheArgsFieldResolver(arg: String!): String!
       giveMeTheContextFieldResolver: String!
@@ -124,6 +125,9 @@ const fieldResolverSchema = makeExecutableSchema({
     Plain: {
       fieldResolver() {
         return of("I am a field resolver");
+      },
+      fieldResolvesUndefined() {
+        return of(undefined);
       },
       giveMeTheParentFieldResolver(parent) {
         return of(JSON.stringify(parent));
@@ -391,6 +395,22 @@ describe("graphqlObservable", function() {
           `;
           const expected = m.cold("(a|)", {
             a: { data: { plain: { fieldResolver: "I am a field resolver" } } }
+          });
+          const result = graphql(fieldResolverSchema, query, null, {});
+          m.expect(result.pipe(take(1))).toBeObservable(expected);
+        });
+
+        // fixme: without `only` all tests pass 🤔
+        itMarbles.only("if defined but returns undefined, field is null", function (m) {
+          const query = gql`
+            query {
+              plain {
+                fieldResolvesUndefined
+              }
+            }
+          `;
+          const expected = m.cold("(a|)", {
+            a: { data: { plain: { fieldResolvesUndefined: null } } }
           });
           const result = graphql(fieldResolverSchema, query, null, {});
           m.expect(result.pipe(take(1))).toBeObservable(expected);

--- a/src/__tests__/graphqlObservable-test.ts
+++ b/src/__tests__/graphqlObservable-test.ts
@@ -254,7 +254,7 @@ describe("graphqlObservable", function() {
         }
       `;
 
-      const expectedData = [{ name: "apollo11" }, { name: "challenger" }];
+      const expectedData = [{ name: "apollo11", firstFlight: null }, { name: "challenger", firstFlight: null }];
       const dataSource = of(expectedData);
       const expected = m.cold("(a|)", {
         a: { data: { launched: [expectedData[0]] } }
@@ -286,7 +286,7 @@ describe("graphqlObservable", function() {
         }
       `;
 
-      const expectedData = [{ name: "apollo13" }, { name: "challenger" }];
+      const expectedData = [{ name: "apollo13", firstFlight: null }, { name: "challenger", firstFlight: null }];
       const dataSource = of(expectedData);
       const expected = m.cold("(a|)", {
         a: { data: { launched: [expectedData[0]] } }
@@ -404,8 +404,7 @@ describe("graphqlObservable", function() {
           m.expect(result.pipe(take(1))).toBeObservable(expected);
         });
 
-        // fixme: without `only` all tests pass 🤔
-        itMarbles.only("if defined but returns undefined, field is null", function (m) {
+        itMarbles("if defined but returns undefined, field is null", function (m) {
           const query = gql`
             query {
               plain {

--- a/src/jstutils/isNullish.ts
+++ b/src/jstutils/isNullish.ts
@@ -1,0 +1,8 @@
+// inspired from https://github.com/graphql/graphql-js/blob/926e4d80c558b107c49e9403e943086fa9b043a8/src/jsutils/isNullish.js
+
+/**
+ * Returns true if a value is null, undefined, or NaN.
+ */
+export default function isNullish(value: any) {
+  return value === null || value === undefined || value !== value;
+};

--- a/src/reactive-graphql.ts
+++ b/src/reactive-graphql.ts
@@ -23,6 +23,8 @@ import {
   parse
 } from "graphql";
 
+import isNullish from './jstutils/isNullish';
+
 // WARNING: This is NOT a spec complete graphql implementation
 // https://facebook.github.io/graphql/October2016/
 
@@ -135,7 +137,9 @@ export default function graphql<T = object>(
         context,
         variables,
         parent
-      );
+      )
+      // If result value is null-ish (null, undefined, or NaN) then return null.
+      .pipe(map(value => isNullish(value) ? null : value));
 
       // Directly return the leaf nodes
       if (definition.selectionSet === undefined) {


### PR DESCRIPTION
Fixes #17 

~⚠️I added a failing test case in `993a417`: however, all tests passed even with the failing test case. But it failed (correctly) if I'd run only that case in particular. => #24~