### PR TITLE
Improve asErrorInstance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1507,7 +1507,7 @@
     },
     "colors": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
       "dev": true
     },
@@ -2082,7 +2082,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -4021,7 +4021,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -5114,7 +5114,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -9125,7 +9125,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -10524,7 +10524,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@getstation/reactive-graphql",
+  "name": "reactive-graphql",
   "repository": {
     "type": "git",
     "url": "https://github.com/mesosphere/reactive-graphql"
@@ -9,7 +9,7 @@
   "files": [
     "dist"
   ],
-  "version": "4.0.2",
+  "version": "0.0.0-dev+semantic-release",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "reactive-graphql",
+  "name": "@getstation/reactive-graphql",
   "repository": {
     "type": "git",
     "url": "https://github.com/mesosphere/reactive-graphql"
@@ -9,7 +9,7 @@
   "files": [
     "dist"
   ],
-  "version": "0.0.0-dev+semantic-release",
+  "version": "4.0.2",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/src/execution/execute.ts
+++ b/src/execution/execute.ts
@@ -1,7 +1,7 @@
 /**
  * `execute.ts` is the equivalent of `graphql-js`'s `src/execution/execute.js`:
  * it follows the same structure and same function names.
- * 
+ *
  * The implementation of each function is very close to its sibling in `graphql-js`
  * and, for the most part, is just adapted for reactive execution (dealing with `Observable`).
  * Some functions are just copy-pasted because they did not require any change
@@ -61,9 +61,9 @@ import mapToFirstValue from "../rxutils/mapToFirstValue";
 
 /**
  * Implements the "Evaluating requests" section of the GraphQL specification.
- * 
+ *
  * Returns a RxJS's `Observable` of `ExecutionResult`.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `execute`.
  */
 export function execute<TData = ExecutionResultDataDefault>(args: ExecutionArgs)
@@ -149,7 +149,7 @@ function executeImpl<TData>(
 
 /**
  * Returns true if subject is a valid `ExecutionContext` and not array of `GraphQLError`.
- * 
+ *
  * Note: reference implementation does a `Array.isArray` in `executeImpl` function body. In comparison,
  * `isValidExecutionContext` ensures typing correctness with type assertion.
  * @param subject value to be tested
@@ -161,7 +161,7 @@ function isValidExecutionContext(subject: ReadonlyArray<GraphQLError> | Executio
 /**
  * Given a completed execution context and data as Observable, build the `{ errors, data }`
  * response defined by the "Response" section of the GraphQL specification.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `buildResponse`.
  */
 function buildResponse<TData>(
@@ -185,7 +185,7 @@ function buildResponse<TData>(
 
 /**
  * Implements the "Evaluating operations" section of the spec.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `executeOperation`. The difference lies
  * in the fact that, here, a RxJS's `Observable` is returned instead of a `Promise` (or plain value).
  */
@@ -225,7 +225,7 @@ function executeOperation(
 /**
  * Implements the "Evaluating selection sets" section of the spec for "write" mode,
  * ie with serial execution.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `executeFieldsSerially`. The difference
  * lies in the fact that:
  * - here, a RxJS's `Observable` is returned instead of a `Promise` (or plain value)
@@ -285,7 +285,7 @@ function executeFieldsSerially(
 /**
  * Implements the "Evaluating selection sets" section of the spec
  * for "read" mode.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `executeFields`. The difference lies
  * in the fact that, here, a RxJS's `Observable` is returned instead of a `Promise` (or plain value).
  */
@@ -320,7 +320,7 @@ function executeFields(
 
 /**
  * Resolves the field on the given source object.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `resolveField`. The difference lies
  * in the fact that, here, a RxJS's `Observable` is returned instead of a `Promise` (or plain value).
  */
@@ -386,9 +386,9 @@ function resolveFieldValueOrError<TSource>(
       fieldNodes[0],
       exeContext.variableValues,
     );
-  
+
     const contextValue = exeContext.contextValue;
-  
+
     const result = resolveFn(source, args, contextValue, info);
 
     if (isObservable(result)) {
@@ -411,11 +411,14 @@ function resolveFieldValueOrError<TSource>(
 /**
  * Sometimes a non-error is thrown, wrap it as an Error instance to ensure a
  * consistent Error interface.
- * 
+ *
  * Note: copy-paste of `graphql-js`'s `asErrorInstance` in `execute.js`.
  */
 function asErrorInstance(error: unknown): Error {
-  return error instanceof Error ? error : new Error(String(error) || undefined);
+  if (error instanceof Error) {
+    return error;
+  }
+  return new Error('Unexpected error value: ' + inspect(error));
 }
 
 /**
@@ -602,7 +605,7 @@ function completeValue(
 /**
  * Complete a list value by completing each item in the list with the
  * inner type
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `completeListValue`. The difference lies
  * in the fact that, here, we deal with RxJS's `Observable` and an `Observable` is returned.
  */
@@ -645,7 +648,7 @@ function completeListValue(
 /**
  * Complete a Scalar or Enum by serializing to a valid value, returning
  * null if serialization is not possible.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `completeLeafValue`. The difference lies
  * in the fact that, here, an `Observable` is returned.
  */
@@ -663,7 +666,7 @@ function completeLeafValue(returnType: GraphQLLeafType, result: unknown): Observ
 /**
  * Complete a value of an abstract type by determining the runtime object type
  * of that value, then complete the value for that type.
- * 
+ *
  * Note: reactive equivalent of `graphql-js`'s `completeAbstractValue`. The difference lies
  * in the fact that, here, we deal with asychronisity in a Observable fashion and that
  * an `Observable` is returned.
@@ -792,7 +795,7 @@ function completeObjectValue(
 }
 
 /**
- * 
+ *
  * Note: copy-pasted from `graphql-js`.
  */
 function invalidReturnTypeError(
@@ -827,7 +830,7 @@ function collectAndExecuteSubfields(
  * A memoized collection of relevant subfields with regard to the return
  * type. Memoizing ensures the subfields are not repeatedly calculated, which
  * saves overhead when resolving lists of values.
- * 
+ *
  * Note: copy-pasted from `graphql-js`. The difference lies in the fact that
  * `graphql-js` implements its own memoization, while we use `memoizee` package.
  */

--- a/src/jstutils/inspect.ts
+++ b/src/jstutils/inspect.ts
@@ -1,6 +1,126 @@
-// @ts-ignore nodeJS typescript not loaded
-import * as util from 'util';
+// @flow strict
 
-export default function inspect(smthing: unknown) {
-  return util.inspect(smthing);
+import nodejsCustomInspectSymbol from './nodejsCustomInspectSymbol';
+
+const MAX_ARRAY_LENGTH = 10;
+const MAX_RECURSIVE_DEPTH = 2;
+
+/**
+ * Used to print values in error messages.
+ */
+export default function inspect(value: any): string {
+  return formatValue(value, []);
+}
+
+function formatValue(value, seenValues) {
+  switch (typeof value) {
+    case 'string':
+      return JSON.stringify(value);
+    case 'function':
+      return value.name ? `[function ${value.name}]` : '[function]';
+    case 'object':
+      if (value === null) {
+        return 'null';
+      }
+      return formatObjectValue(value, seenValues);
+    default:
+      return String(value);
+  }
+}
+
+function formatObjectValue(value, previouslySeenValues) {
+  if (previouslySeenValues.indexOf(value) !== -1) {
+    return '[Circular]';
+  }
+
+  const seenValues = [...previouslySeenValues, value];
+  const customInspectFn = getCustomFn(value);
+
+  if (customInspectFn !== undefined) {
+    // $FlowFixMe(>=0.90.0)
+    const customValue = customInspectFn.call(value);
+
+    // check for infinite recursion
+    if (customValue !== value) {
+      return typeof customValue === 'string'
+        ? customValue
+        : formatValue(customValue, seenValues);
+    }
+  } else if (Array.isArray(value)) {
+    return formatArray(value, seenValues);
+  }
+
+  return formatObject(value, seenValues);
+}
+
+function formatObject(object, seenValues) {
+  const keys = Object.keys(object);
+  if (keys.length === 0) {
+    return '{}';
+  }
+
+  if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+    return '[' + getObjectTag(object) + ']';
+  }
+
+  const properties = keys.map((key) => {
+    const value = formatValue(object[key], seenValues);
+    return key + ': ' + value;
+  });
+
+  return '{ ' + properties.join(', ') + ' }';
+}
+
+function formatArray(array, seenValues) {
+  if (array.length === 0) {
+    return '[]';
+  }
+
+  if (seenValues.length > MAX_RECURSIVE_DEPTH) {
+    return '[Array]';
+  }
+
+  const len = Math.min(MAX_ARRAY_LENGTH, array.length);
+  const remaining = array.length - len;
+  const items: any[] = [];
+
+  for (let i = 0; i < len; ++i) {
+    items.push(formatValue(array[i], seenValues));
+  }
+
+  if (remaining === 1) {
+    items.push('... 1 more item');
+  } else if (remaining > 1) {
+    items.push(`... ${remaining} more items`);
+  }
+
+  return '[' + items.join(', ') + ']';
+}
+
+function getCustomFn(object) {
+  const customInspectFn = object[String(nodejsCustomInspectSymbol)];
+
+  if (typeof customInspectFn === 'function') {
+    return customInspectFn;
+  }
+
+  if (typeof object.inspect === 'function') {
+    return object.inspect;
+  }
+}
+
+function getObjectTag(object) {
+  const tag = Object.prototype.toString
+    .call(object)
+    .replace(/^\[object /, '')
+    .replace(/]$/, '');
+
+  if (tag === 'Object' && typeof object.constructor === 'function') {
+    const name = object.constructor.name;
+    if (typeof name === 'string' && name !== '') {
+      return name;
+    }
+  }
+
+  return tag;
 }

--- a/src/jstutils/nodejsCustomInspectSymbol.ts
+++ b/src/jstutils/nodejsCustomInspectSymbol.ts
@@ -1,0 +1,7 @@
+// istanbul ignore next (See: 'https://github.com/graphql/graphql-js/issues/2317')
+const nodejsCustomInspectSymbol =
+  typeof Symbol === 'function' && typeof Symbol.for === 'function'
+    ? Symbol.for('nodejs.util.inspect.custom')
+    : undefined;
+
+export default nodejsCustomInspectSymbol;


### PR DESCRIPTION
Currently `asErrorInstance` stringifies objects like this: `[object Object]`, which is not a really usuful error message.
This PR takes last `asErrorInstance` fron `graphql-js` that does a better job at serializing errors